### PR TITLE
mitigate race condition between stdout flushing and process exit

### DIFF
--- a/lib/sandbox.js
+++ b/lib/sandbox.js
@@ -28,7 +28,7 @@ function Sandbox( options ) {
     child.stdout.on( 'data', output )
     child.stderr.on( 'data', outputErr )
 
-    child.on( 'exit', function( code ) {
+    child.on( 'close', function( code ) {
       clearTimeout( timer )
       if (stderr) {
         var without_traces = stderr.replace(/\s{4}at(.*)(\n)*/ig, '');
@@ -51,7 +51,7 @@ function Sandbox( options ) {
     child.stdin.write( code )
     child.stdin.end()
     timer = setTimeout( function() {
-      child.stdout.removeListener( 'output', output )
+      child.stdout.removeListener( 'data', output )
       stdout = JSON.stringify( { result: 'TimeoutError', console: [] } )
       child.kill( 'SIGKILL' )
     }, this.options.timeout )


### PR DESCRIPTION
This mitigates the race condition between stdout being not fully flushed at the time the process exits, which results in occasional `Unexpected end of input` errors when processing output of node-sandbox. 

After this is taken, shrinkwrap for auth0-users and auth0-server needs to be redone.
